### PR TITLE
RM-71412 Fixup to add lifecyle and tags

### DIFF
--- a/README-EditShare.md
+++ b/README-EditShare.md
@@ -1,0 +1,11 @@
+This is a fork of the cloud\_deployment\_scripts repo from HP\_Inc.  It has been named cloud\_deployment\_scripts\_hp\_inc to distinguish it from the initial fork we did from that repo, which was before Teradici was purchased by HP.
+
+The contents of the repo are left mostly unchanged, especially for the Connector and Manager.  A summary of what has been changed and why is provided below
+
+- removed all `version.tf` and `provider.tf` files: This is done because the original repo acts as a standalone terraform project, and as such it defines that information in multiple locations.  However we treat this as a submodule (think library), and as such all of those definitions conflict with the baselines we have established.  Shell scripts have been added to the root of the repo to assist in cleaning up all those files.
+- awc: The provisioning script has been modified to install and configure `socat`, which we use to forward RDP sessions to the domain controller.  This is a useful extension since the domain controller only has a private IP in Cloud Edit+ deployments.  Also added a lifecyle block to prevent the instance from being replaced if the AMI selected happens to change, and tags to the root\_block\_device.
+- awm: Added a lifecyle block to prevent the instance from being replaced if the AMI selected happens to change, and tags to the root\_block\_device.
+
+In addition to the above changes, there are some notes about the EditShare use of this repo
+- dc: There are a few changes here, that were significant enough that we made our own copy of the modules/aws/dc set of code and modified things there.  The most notable change at this point is adding a lifecycle block to prevent the instance from being replaced if the AMI selected happens to change.  Our version of the DC is maintained in the terraform-deploy repo.
+- cas-mgr-single-connector: There are a number of changes to help ensure that the CAS components are deployed in accordance with the Cloud Edit+ architecture, including ensuring that the domain controller is in a private subnet.  We also eliminate anything to do with creating workstations, since those are managed by the terraform-deploy repo at a layer above this submodule.  Our version of the cas-mgr-single-connector is maintained in the terraform-deploy repo.

--- a/modules/aws/awm/main.tf
+++ b/modules/aws/awm/main.tf
@@ -201,6 +201,12 @@ resource "aws_instance" "awm" {
   root_block_device {
     volume_type = "gp2"
     volume_size = var.disk_size_gb
+    tags = merge(
+      {
+        Name = "vol-${var.prefix}-sda1-manager"
+      },
+      {Environment = "${var.prefix}"} # var.common_tags
+    )
   }
 
   associate_public_ip_address = var.enable_public_ip
@@ -212,6 +218,23 @@ resource "aws_instance" "awm" {
   iam_instance_profile = aws_iam_instance_profile.awm-instance-profile.name
 
   user_data = data.template_file.user-data.rendered
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to user_data, since we only use it when
+      # the node initializes and we do not want subsequent
+      # enhancements to user_data to cause the node to be replaced
+      user_data,
+      # Since the DC runs on a standard AWS Windows Server, it's possible that
+      # AWS will eventually age out the AMI used to initially deploy the DC,
+      # so we ignore AMI changes here
+      ami,
+      # if the ec2 instance_type is changed from the AWS Console, it will
+      # cause terraform to think the ebs_optimized field has changed and
+      # the instance will be replaced, so we ignore that field here
+      ebs_optimized,
+    ]
+  }
 
   tags = {
     Name = "${local.prefix}${var.host_name}"


### PR DESCRIPTION
Missed our enhancements to add lifecycle blocks and tags to the root_block_device on the connector and manager modules, so picking those up now.

References RM-71412