### PR TITLE
RM-72501 Fix cron job for connector_log_manager

### DIFF
--- a/modules/aws/awc/user-data.sh.tmpl
+++ b/modules/aws/awc/user-data.sh.tmpl
@@ -84,7 +84,7 @@ fi
 log "--> Creating cron job for log manager script..."
 cat > /etc/cron.weekly/connector_log_manager << EOF
 #!/bin/bash
-python3 /home/rocky/connector_log_manager.py
+python3 /root/connector_log_manager.py
 EOF
 chmod +x /etc/cron.weekly/connector_log_manager
 


### PR DESCRIPTION
Fixing where cron job finds the script, which should be /root since the user-data runs as root and just downloads the script from S3 to the local directory.

References RM-72501