### PR TITLE
RM-72791 Add common_tags to HPA instances

### DIFF
--- a/modules/aws/awc/main.tf
+++ b/modules/aws/awc/main.tf
@@ -294,10 +294,10 @@ resource "aws_instance" "awc" {
     volume_type = "gp2"
     volume_size = var.disk_size_gb
     tags = merge(
-      { 
+      {
         Name = "vol-${var.prefix}-sda1-connector"
       },
-      {Environment = "${var.prefix}"} # var.common_tags
+      var.common_tags
     )
   }
 
@@ -328,9 +328,12 @@ resource "aws_instance" "awc" {
     ]
   }
 
-  tags = {
-    Name = "${local.prefix}${var.host_name}-${count.index}"
-  }
+  tags = merge(
+    {
+      Name = "${local.prefix}${var.host_name}-${count.index}"
+    },
+    var.common_tags
+  )
 }
 
 resource "aws_cloudwatch_dashboard" "awc" {

--- a/modules/aws/awc/vars.tf
+++ b/modules/aws/awc/vars.tf
@@ -211,3 +211,9 @@ variable "win_std_instance_count" {
   default     = 0
 }
 
+# EditShare-specific
+variable "common_tags" {
+  description = "Common Tags to use for all resources"
+  type        = map(any)
+  default     = {}
+}

--- a/modules/aws/awm/main.tf
+++ b/modules/aws/awm/main.tf
@@ -205,7 +205,7 @@ resource "aws_instance" "awm" {
       {
         Name = "vol-${var.prefix}-sda1-manager"
       },
-      {Environment = "${var.prefix}"} # var.common_tags
+      var.common_tags
     )
   }
 
@@ -236,7 +236,10 @@ resource "aws_instance" "awm" {
     ]
   }
 
-  tags = {
-    Name = "${local.prefix}${var.host_name}"
-  }
+  tags = merge(
+    {
+      Name = "${local.prefix}${var.host_name}"
+    },
+    var.common_tags
+  )
 }

--- a/modules/aws/awm/vars.tf
+++ b/modules/aws/awm/vars.tf
@@ -117,3 +117,10 @@ variable "aws_ssm_enable" {
   description = "Enable AWS Session Manager integration for easier SSH/RDP admin access to EC2 instances"
   default     = true
 }
+
+# EditShare-specific
+variable "common_tags" {
+  description = "Common Tags to use for all resources"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
Need to add common_tags to the awm and aws so they can be properly Stopped by the terraform-deploy destroy.sh processing.  Not updating the dc module here because we use one specific to EditShare that is implemented in the terraform-deploy code base.

References RM-72791