### PR TITLE
Fix to AWS Credentials Decryption & Code Clean

### DIFF
--- a/modules/aws/awm/awm-provisioning.sh.tmpl
+++ b/modules/aws/awm/awm-provisioning.sh.tmpl
@@ -134,7 +134,7 @@ get_credentials() {
         if [ "$AWM_AWS_CREDENTIALS_FILE" ]
         then
             log "--> Decrypting AWS Service Account credentials file..."
-            aws kms decrypt --region $AWS_REGION --ciphertext-blob "fileb://$INSTALL_DIR/$AWM_AWS_CREDENTIALS_FILE" --output text --query Plaintext | base64 -d > "$INSTALL_DIR/$AWM_AWS_CREDENTIALS_FILE.decrypted"
+            printf "%b" "$(aws kms decrypt --region $AWS_REGION --ciphertext-blob "file://$INSTALL_DIR/$AWM_AWS_CREDENTIALS_FILE" --output text --query Plaintext | base64 -d)" > "$INSTALL_DIR/$AWM_AWS_CREDENTIALS_FILE.decrypted"
             mv "$AWM_AWS_CREDENTIALS_FILE.decrypted" "$INSTALL_DIR/$AWM_AWS_CREDENTIALS_FILE"
         fi
     fi

--- a/modules/aws/awm/awm-setup.py
+++ b/modules/aws/awm/awm-setup.py
@@ -15,10 +15,11 @@ from botocore.exceptions import ClientError
 AWM_API_URL = "https://localhost/api/v1"
 ADMIN_USER = "adminUser"
 
+
 def awm_login(username, password):
     payload = {
-        'username': username,
-        'password': password,
+        "username": username,
+        "password": password,
     }
     resp = session.post(
         f"{AWM_API_URL}/auth/ad/login",
@@ -26,40 +27,37 @@ def awm_login(username, password):
     )
     resp.raise_for_status()
 
-    token = resp.json()['data']['token']
+    token = resp.json()["data"]["token"]
     session.headers.update({"Authorization": token})
 
 
 def deployment_create(name, reg_code):
     payload = {
-        'deploymentName':   name,
-        'registrationCode': reg_code,
+        "deploymentName": name,
+        "registrationCode": reg_code,
     }
     resp = session.post(
         f"{AWM_API_URL}/deployments",
-        json = payload,
+        json=payload,
     )
     resp.raise_for_status()
 
-    return resp.json()['data']
+    return resp.json()["data"]
 
 
 def deployment_key_create(deployment, name):
-    payload = {
-        'deploymentId': deployment['deploymentId'],
-        'keyName': name
-    }
+    payload = {"deploymentId": deployment["deploymentId"], "keyName": name}
     resp = session.post(
         f"{AWM_API_URL}/auth/keys",
-        json = payload,
+        json=payload,
     )
     resp.raise_for_status()
 
-    return resp.json()['data']
+    return resp.json()["data"]
 
 
 def deployment_key_write(deployment_key, path):
-    with open(path, 'w') as f:
+    with open(path, "w") as f:
         json.dump(deployment_key, f)
 
 
@@ -67,16 +65,16 @@ def get_aws_sa_key(path):
     config = configparser.ConfigParser()
     config.read(path)
 
-    return config['default']
+    return config["default"]
 
 
 def get_username(key):
-    iam = boto3.resource('iam')
+    iam = boto3.resource("iam")
     try:
         resp = iam.meta.client.get_access_key_last_used(
-            AccessKeyId=key['aws_access_key_id']
+            AccessKeyId=key["aws_access_key_id"]
         )
-        return resp['UserName']
+        return resp["UserName"]
     except ClientError as e:
         # Not failing because AWS service account is optional
         print("Warning: error retrieving AWS username.")
@@ -86,16 +84,16 @@ def get_username(key):
 def validate_aws_sa(username, key):
     print("Validating AWS credentials with Anyware Manager...")
     payload = {
-        'provider': 'aws',
-        'credential': {
-            'userName': username,
-            'accessKeyId': key['aws_access_key_id'],
-            'secretAccessKey': key['aws_secret_access_key'],
+        "provider": "aws",
+        "credential": {
+            "userName": username,
+            "accessKeyId": key["aws_access_key_id"],
+            "secretAccessKey": key["aws_secret_access_key"],
         },
     }
     resp = session.post(
         f"{AWM_API_URL}/auth/users/cloudServiceAccount/validate",
-        json = payload,
+        json=payload,
     )
     try:
         resp.raise_for_status()
@@ -106,25 +104,27 @@ def validate_aws_sa(username, key):
         print(e)
 
         if resp.status_code == 400:
-            print("Warning: error AWS Service Account key provided has insufficient permissions.")
-            print(resp.json()['data'])
+            print(
+                "Warning: error AWS Service Account key provided has insufficient permissions."
+            )
+            print(resp.json()["data"])
 
         return False
 
 
 def deployment_add_aws_account(username, key, deployment):
     credentials = {
-        'userName': username,
-        'accessKeyId': key['aws_access_key_id'],
-        'secretAccessKey': key['aws_secret_access_key'],
+        "userName": username,
+        "accessKeyId": key["aws_access_key_id"],
+        "secretAccessKey": key["aws_secret_access_key"],
     }
     payload = {
-        'provider': 'aws',
-        'credential': credentials,
+        "provider": "aws",
+        "credential": credentials,
     }
     resp = session.post(
         f"{AWM_API_URL}/deployments/{deployment['deploymentId']}/cloudServiceAccounts",
-        json = payload,
+        json=payload,
     )
 
     try:
@@ -136,13 +136,27 @@ def deployment_add_aws_account(username, key, deployment):
         print(e)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="This script updates the password for the Anyware Manager Admin user.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="This script updates the password for the Anyware Manager Admin user."
+    )
 
-    parser.add_argument("--deployment_name", required=True, help="Anyware Manager deployment to create")
-    parser.add_argument("--key_file", required=True, help="path to write Deployment Service Account key JSON file")
-    parser.add_argument("--key_name", required=True, help="name of Anyware Manager Deployment Service Account key")
-    parser.add_argument("--password", required=True, help="new Anyware Manager administrator password")
+    parser.add_argument(
+        "--deployment_name", required=True, help="Anyware Manager deployment to create"
+    )
+    parser.add_argument(
+        "--key_file",
+        required=True,
+        help="path to write Deployment Service Account key JSON file",
+    )
+    parser.add_argument(
+        "--key_name",
+        required=True,
+        help="name of Anyware Manager Deployment Service Account key",
+    )
+    parser.add_argument(
+        "--password", required=True, help="new Anyware Manager administrator password"
+    )
     parser.add_argument("--reg_code", required=True, help="PCoIP registration code")
     parser.add_argument("--aws_key", help="AWS Service Account credentials INI file")
 
@@ -154,12 +168,10 @@ if __name__ == '__main__':
     retry_strategy = requests.adapters.Retry(
         total=10,
         backoff_factor=1,
-        status_forcelist=[500,502,503,504],
-        allowed_methods=["POST"] # "method_whitelist" deprecated
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["POST"],  # "method_whitelist" deprecated
     )
-    session.mount(
-        "https://", requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-    )
+    session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retry_strategy))
 
     # The credential for Anyware Manager login are stated in default configuration
     # https://www.teradici.com/web-help/anyware_manager/23.04/cam_standalone_installation/default_config/#5-access-the-admin-console

--- a/modules/aws/awm/awm-setup.py
+++ b/modules/aws/awm/awm-setup.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+################################################
+# Note this file has EditShare Customizations. #
+################################################
+
 # Copyright (c) 2020 Teradici Corporation;  © Copyright 2023 HP Development Company, L.P.
 #
 # This source code is licensed under the MIT license found in the
@@ -7,8 +11,9 @@
 
 import argparse
 import json
-import requests
 import configparser
+from typing import Any
+import requests
 import boto3
 from botocore.exceptions import ClientError
 
@@ -16,27 +21,29 @@ AWM_API_URL = "https://localhost/api/v1"
 ADMIN_USER = "adminUser"
 
 
-def awm_login(username, password):
+def awm_login(user_name: str, password: str, req_sess: requests.Session) -> None:
+    """Login to Anyware Manager API and set token to session."""
     payload = {
-        "username": username,
+        "username": user_name,
         "password": password,
     }
-    resp = session.post(
+    resp = req_sess.post(
         f"{AWM_API_URL}/auth/ad/login",
         json=payload,
     )
     resp.raise_for_status()
 
     token = resp.json()["data"]["token"]
-    session.headers.update({"Authorization": token})
+    req_sess.headers.update({"Authorization": token})
 
 
-def deployment_create(name, reg_code):
+def deployment_create(name: str, reg_code: str, req_sess: requests.Session) -> Any:
+    """Create new Anyware Manager deployment."""
     payload = {
         "deploymentName": name,
         "registrationCode": reg_code,
     }
-    resp = session.post(
+    resp = req_sess.post(
         f"{AWM_API_URL}/deployments",
         json=payload,
     )
@@ -45,9 +52,12 @@ def deployment_create(name, reg_code):
     return resp.json()["data"]
 
 
-def deployment_key_create(deployment, name):
-    payload = {"deploymentId": deployment["deploymentId"], "keyName": name}
-    resp = session.post(
+def deployment_key_create(
+    deployment_info: dict, name: str, req_sess: requests.Session  # type: ignore
+) -> Any:
+    """Create new Anyware Manager deployment key."""
+    payload = {"deploymentId": deployment_info["deploymentId"], "keyName": name}
+    resp = req_sess.post(
         f"{AWM_API_URL}/auth/keys",
         json=payload,
     )
@@ -56,23 +66,26 @@ def deployment_key_create(deployment, name):
     return resp.json()["data"]
 
 
-def deployment_key_write(deployment_key, path):
-    with open(path, "w") as f:
+def deployment_key_write(deployment_key: str, path: str) -> None:
+    """Write Anyware Manager deployment key to file."""
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(deployment_key, f)
 
 
-def get_aws_sa_key(path):
+def get_aws_sa_key(path: str) -> configparser.SectionProxy:
+    """Return AWS credentials from INI file"""
     config = configparser.ConfigParser()
     config.read(path)
 
     return config["default"]
 
 
-def get_username(key):
+def get_username(aws_key: configparser.SectionProxy) -> Any:
+    """Get AWS username associated with the provided AWS credentials."""
     iam = boto3.resource("iam")
     try:
         resp = iam.meta.client.get_access_key_last_used(
-            AccessKeyId=key["aws_access_key_id"]
+            AccessKeyId=aws_key["aws_access_key_id"]
         )
         return resp["UserName"]
     except ClientError as e:
@@ -81,17 +94,20 @@ def get_username(key):
         print(e)
 
 
-def validate_aws_sa(username, key):
+def validate_aws_sa(
+    user_name: str, aws_key: configparser.SectionProxy, req_sess: requests.Session
+) -> bool:
+    """Validate AWS credentials with Anyware Manager."""
     print("Validating AWS credentials with Anyware Manager...")
     payload = {
         "provider": "aws",
         "credential": {
-            "userName": username,
-            "accessKeyId": key["aws_access_key_id"],
-            "secretAccessKey": key["aws_secret_access_key"],
+            "userName": user_name,
+            "accessKeyId": aws_key["aws_access_key_id"],
+            "secretAccessKey": aws_key["aws_secret_access_key"],
         },
     }
-    resp = session.post(
+    resp = req_sess.post(
         f"{AWM_API_URL}/auth/users/cloudServiceAccount/validate",
         json=payload,
     )
@@ -112,18 +128,24 @@ def validate_aws_sa(username, key):
         return False
 
 
-def deployment_add_aws_account(username, key, deployment):
+def deployment_add_aws_account(
+    user_name: str,
+    aws_key: configparser.SectionProxy,
+    deployment_info: dict,  # type: ignore
+    req_sess: requests.Session,
+) -> None:
+    """Add AWS credentials to Anyware Manager deployment."""
     credentials = {
-        "userName": username,
-        "accessKeyId": key["aws_access_key_id"],
-        "secretAccessKey": key["aws_secret_access_key"],
+        "userName": user_name,
+        "accessKeyId": aws_key["aws_access_key_id"],
+        "secretAccessKey": aws_key["aws_secret_access_key"],
     }
     payload = {
         "provider": "aws",
         "credential": credentials,
     }
-    resp = session.post(
-        f"{AWM_API_URL}/deployments/{deployment['deploymentId']}/cloudServiceAccounts",
+    resp = req_sess.post(
+        f"{AWM_API_URL}/deployments/{deployment_info['deploymentId']}/cloudServiceAccounts",
         json=payload,
     )
 
@@ -176,16 +198,16 @@ if __name__ == "__main__":
     # The credential for Anyware Manager login are stated in default configuration
     # https://www.teradici.com/web-help/anyware_manager/23.04/cam_standalone_installation/default_config/#5-access-the-admin-console
     print("Creating Anyware Manager deployment...")
-    awm_login(ADMIN_USER, args.password)
-    deployment = deployment_create(args.deployment_name, args.reg_code)
-    awm_deployment_key = deployment_key_create(deployment, args.key_name)
+    awm_login(ADMIN_USER, args.password, session)
+    deployment = deployment_create(args.deployment_name, args.reg_code, session)
+    awm_deployment_key = deployment_key_create(deployment, args.key_name, session)
     deployment_key_write(awm_deployment_key, args.key_file)
 
     if args.aws_key:
         key = get_aws_sa_key(args.aws_key)
         username = get_username(key)
-        if username and validate_aws_sa(username, key):
+        if username and validate_aws_sa(username, key, session):
             print("Adding AWS credentials to Anyware Manager deployment...")
-            deployment_add_aws_account(username, key, deployment)
+            deployment_add_aws_account(username, key, deployment, session)
         else:
             print("Skip adding AWS credentials to Anyware Manager deployment.")


### PR DESCRIPTION
This change fixes an issue where when we are providing the AWS Credentials as a file to the HPA Modules, it expects them in binary form - however we are unable to provide them in that way via Terraform; so we switch the decryption process to target a non binary file, and also `printf` it to retain the `\n` characters resulting in a valid AWS credentials ini file

All changes to the `awm-setup.py` script are code style, linting and typing - no functional changes were required to this file after these were done - but they are nice to keep for the future should we wish to extend this script at all.

Ref CP-326